### PR TITLE
Custom animated visibility scope transition state in StackAnimator

### DIFF
--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/NavHost.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/NavHost.kt
@@ -1,5 +1,6 @@
 package com.nxoim.decomposite.core.common.navigation
 
+import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.NonRestartableComposable
@@ -38,7 +39,7 @@ inline fun <reified C : Any> NavHost(
     modifier: Modifier = Modifier,
     noinline animations: DestinationAnimationsConfiguratorScope<C>.() -> ContentAnimations =
         LocalContentAnimator.current,
-    crossinline router: @Composable (destination: C) -> Unit,
+    crossinline router: @Composable AnimatedVisibilityScope.(destination: C) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val screenStackAnimatorScope = rememberStackAnimatorScope<C>(

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
@@ -130,7 +130,7 @@ data class AnimationStatus(
 sealed class ItemLocation(val indexFromTop: Int) {
 	data class Back(private val _indexFromTop: Int) : ItemLocation(_indexFromTop)
 	data object Top : ItemLocation(0)
-	data object Outside : ItemLocation(-1)
+	data class Outside(private val _indexFromTop: Int) : ItemLocation(_indexFromTop)
 
 	companion object {
 		val ItemLocation.top get() = this == Top
@@ -139,7 +139,7 @@ sealed class ItemLocation(val indexFromTop: Int) {
 		/**
 		 * Only happens upon removal of an item from the stack
 		 */
-		val ItemLocation.outside get() = this == Outside
+		val ItemLocation.outside get() = this is Outside
 	}
 }
 

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
@@ -1,43 +1,166 @@
 package com.nxoim.decomposite.core.common.navigation.animations
 
+import com.nxoim.decomposite.core.common.navigation.animations.AnimationType.Companion.gestures
+import com.nxoim.decomposite.core.common.navigation.animations.AnimationType.Companion.none
+import com.nxoim.decomposite.core.common.navigation.animations.AnimationType.Companion.passive
+import com.nxoim.decomposite.core.common.navigation.animations.AnimationType.Companion.passiveCancelling
+import com.nxoim.decomposite.core.common.navigation.animations.Direction.Companion.inwards
+import com.nxoim.decomposite.core.common.navigation.animations.Direction.Companion.none
+import com.nxoim.decomposite.core.common.navigation.animations.Direction.Companion.outwards
+import com.nxoim.decomposite.core.common.navigation.animations.ItemLocation.Companion.back
+import com.nxoim.decomposite.core.common.navigation.animations.ItemLocation.Companion.outside
+import com.nxoim.decomposite.core.common.navigation.animations.ItemLocation.Companion.top
+
 /**
- * Base for the animation status. [animating] is used in the [StackAnimator] for managing content
- * visibility so it's important to provide it correctly.
+ * Represents the status of an animation.
+ *
+ * [previousLocation] must represent the previous location of an item in the stack.
+ * If the item has not been moved in the stack - [previousLocation] must be null.
+ *
+ * [location] must represent the current location of an item in the stack
+ * (irrespective of the animation) and it's changes must trigger the animation.
+ *
+ * [direction] must represent the direction of the animation even when animating
+ * with gestures.
+ *
+ * [animationType] must represent the type of the current animation.
  */
-interface AnimationStatus {
-    val animating: Boolean
+data class AnimationStatus(
+	val previousLocation: ItemLocation?,
+	val location: ItemLocation,
+	val direction: Direction,
+	val animationType: AnimationType
+) {
+	init {
+		if ((direction.none && !animationType.none) || (!direction.none && animationType.none)) {
+			error("direction must not be none if animation type is not none, and vice versa. Incorrect state: $this")
+		}
+	}
+	val animating = !animationType.none && !direction.none
+
+	/**
+	 * This is true when the animation(gestures and passive, excluding the
+	 * navigation cancellation animation) targets the top of the stack from the back.
+	 *
+	 * Example: removal of an item from the stack while this item was in the back
+	 */
+	val fromBackIntoTop
+		get() = (location.indexFromTop == 1 && animationType.gestures)
+				|| (location.top && previousLocation != null && previousLocation.back && direction.outwards && !animationType.passiveCancelling)
+
+	/**
+	 * This is true when the animation(passive, excluding the navigation cancellation
+	 * animation) targets the back of the stack from the top.
+	 *
+	 * Example: addition of an item to the stack when this item was at the top
+	 */
+	val fromTopIntoBack
+		get() = location.back
+				&& previousLocation != null
+				&& previousLocation.top
+				&& direction.inwards
+				&& !animationType.passiveCancelling
+
+	/**
+	 * This is true when the animation(gestures and passive, excluding the
+	 * 	navigation cancellation animation) targets outside of the stack from the top.
+	 *
+	 * 	Example: removal of an item from the stack
+	 */
+	val fromTopToOutside
+		get() = (location.top && animationType.gestures && direction.outwards)
+				|| (location.outside && previousLocation != null && previousLocation.top && direction.outwards && !animationType.passiveCancelling)
+
+	/**
+	 * This is true when the animation(passive, excluding the navigation cancellation
+	 * animation) targets the top of the stack from outside.
+	 *
+	 * Example: addition of this item to stack.
+	 */
+	val fromOutsideIntoTop
+		get() = location.top
+				&& animationType.passive
+				&& direction.inwards
+				&& (previousLocation == null || previousLocation.outside)
+
+	/**
+	 * This is true when this item is going from a position in the back to another
+	 * position in the back that is closer to the top, e.g. from 2 to
+	 * 1 (0 being the top of the stack).
+	 *
+	 * Example: removal of an item from the stack while this item was (and will
+	 * still be) in the back.
+	 */
+	val fromLowerBackIntoUpper
+		get() = previousLocation != null
+				&& previousLocation.indexFromTop > location.indexFromTop
+				&& !animationType.passiveCancelling
+
+	/**
+	 * This is true when this item is going from a position in the back to another
+	 * position in the back that is closer to the bottom, e.g. from 1 to
+	 * 2 (0 being the top of the stack).
+	 *
+	 * Example: addition of an item to the stack when this item was (and will still
+	 * be) in the back.
+	 */
+	val fromUpperBackIntoLower
+		get() = previousLocation != null
+				&& previousLocation.indexFromTop < location.indexFromTop
+				&& !animationType.passiveCancelling
+
+	/**
+	 * This is true when this item is going from a position in the back to
+	 * another position in the back in any order, e.g. from 2 to 1, or from
+	 * 1 to 2 (0 being the top of the stack).
+	 */
+	val fromBackToBack = fromUpperBackIntoLower || fromLowerBackIntoUpper
 }
 
 /**
- * Default animation status implementation that allows for flexible management of the animation.
+ * Represents the location of an item in the stack.
+ * [indexFromTop] is the index of the item from the top of the stack, with 0 being the top.
+ * Negative [indexFromTop] represents an item not existing in the stack.
  */
-data class DefaultAnimationStatus(
-    val previousLocation: ItemLocation,
-    val location: ItemLocation,
-    val direction: Direction,
-    val type: AnimationType
-) : AnimationStatus{
-    override val animating = !type.none || !direction.none
+sealed class ItemLocation(val indexFromTop: Int) {
+	data class Back(private val _indexFromTop: Int) : ItemLocation(_indexFromTop)
+	data object Top : ItemLocation(0)
+	data object Outside : ItemLocation(-1)
+
+	companion object {
+		val ItemLocation.top get() = this == Top
+		val ItemLocation.back get() = this is Back
+
+		/**
+		 * Only happens upon removal of an item from the stack
+		 */
+		val ItemLocation.outside get() = this == Outside
+	}
 }
 
-enum class ItemLocation { Back, Top, Outside }
+/**
+ * Represents the direction of an animation.
+ */
+enum class Direction {
+	None, Inwards, Outwards;
 
-val ItemLocation.top get() = this == ItemLocation.Top
-
-val ItemLocation.back get() = this == ItemLocation.Back
+	companion object {
+		val Direction.inwards get() = this == Inwards
+		val Direction.outwards get() = this == Outwards
+		val Direction.none get() = this == None
+	}
+}
 
 /**
- * Only happens upon removal of an item from the stack
+ * Represents the type of an animation.
  */
-val ItemLocation.outside get() = this == ItemLocation.Outside
+enum class AnimationType {
+	None, Gestures, Passive, PassiveCancelling;
 
-enum class Direction { None, Inward, Outward }
-val Direction.inward get() = this == Direction.Inward
-val Direction.outward get() = this == Direction.Outward
-val Direction.none get() = this == Direction.None
-
-enum class AnimationType { None, Gestures, Passive }
-
-val AnimationType.gestures get() = this == AnimationType.Gestures
-val AnimationType.passive get() = this == AnimationType.Passive
-val AnimationType.none get() = this == AnimationType.None
+	companion object {
+		val AnimationType.gestures get() = this == Gestures
+		val AnimationType.passive get() = this == Passive
+		val AnimationType.passiveCancelling get() = this == PassiveCancelling
+		val AnimationType.none get() = this == None
+	}
+}

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
@@ -55,7 +55,7 @@ data class AnimationStatus(
 	 * Example: addition of an item to the stack when this item was at the top
 	 */
 	val fromTopIntoBack
-		get() = location.back
+		get() = location.indexFromTop == 1
 				&& previousLocation != null
 				&& previousLocation.top
 				&& direction.inwards
@@ -87,7 +87,7 @@ data class AnimationStatus(
 				&& animationType.passive
 				&& direction.inwards
 				&& (previousLocation == null || previousLocation.outside)
-
+				&& !animationType.passiveCancelling
 	/**
 	 * This is true when this item is going from a position in the back to another
 	 * position in the back that is closer to the top, e.g. from 2 to
@@ -120,6 +120,21 @@ data class AnimationStatus(
 	 * 1 to 2 (0 being the top of the stack).
 	 */
 	val fromBackToBack = fromUpperBackIntoLower || fromLowerBackIntoUpper
+
+	val targetingTop
+		get() = (location.top && (animationType.passiveCancelling || !direction.outwards))
+				|| fromOutsideIntoTop
+				|| fromBackToBack
+
+	val targetingBack
+		get() = (location.back && (animationType.passiveCancelling || !direction.inwards))
+				|| fromTopToOutside
+				|| fromBackToBack
+
+	val targetingOutside
+		get() = (location.outside && (animationType.passiveCancelling || !direction.inwards))
+				|| fromTopToOutside
+				|| fromBackToBack
 }
 
 /**

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
@@ -88,6 +88,20 @@ data class AnimationStatus(
 				&& direction.inwards
 				&& (previousLocation == null || previousLocation.outside)
 				&& !animationType.passiveCancelling
+
+	/**
+	 * This is true when the animation(passive, excluding the navigation cancellation
+	 * animation) targets the outside of the stack from the back.
+	 *
+	 * Example: removal of an item from the stack
+	 */
+	val fromBackToOutside
+		get() = location.outside
+				&& animationType.passive
+				&& direction.outwards
+				&& (previousLocation == null || previousLocation.back)
+				&& !animationType.passiveCancelling
+
 	/**
 	 * This is true when this item is going from a position in the back to another
 	 * position in the back that is closer to the top, e.g. from 2 to

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/AnimationStatus.kt
@@ -67,9 +67,14 @@ data class AnimationStatus(
 	 *
 	 * 	Example: removal of an item from the stack
 	 */
+	// "!location.back" instead of "location.top" because several items
+	// can be removed consecutively and therefore have an indexFromTop
+	// even less than -1, meaning an item can have previousLocation.outside
+	// with location.outside, like backstack items can have previousLocation.back
+	// with location.back
 	val fromTopToOutside
-		get() = (location.top && animationType.gestures && direction.outwards)
-				|| (location.outside && previousLocation != null && previousLocation.top && direction.outwards && !animationType.passiveCancelling)
+		get() = (!location.back && animationType.gestures && direction.outwards)
+				|| (location.outside && previousLocation != null && !previousLocation.back && direction.outwards && !animationType.passiveCancelling)
 
 	/**
 	 * This is true when the animation(passive, excluding the navigation cancellation

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/Animations.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/Animations.kt
@@ -25,6 +25,11 @@ fun emptyAnimation(
 fun fade(
     animationSpec: AnimationSpec<Float> = softSpring(),
     clean: Boolean = true,
+    // alpha needs to be 0.00001f at minimum because of measuring quirks
+    // with lookahead with shared transitions. 0f prevents the composition
+    // and the animation breaks (my assumption. i dont actually know
+    // what the hell is going on)
+    minimumAlpha: Float = 0.000001f,
     animateUsingGestures: Boolean = true
 ) = contentAnimator(animationSpec) {
     Modifier.graphicsLayer {
@@ -34,7 +39,7 @@ fun fade(
             else -> animationProgress
         }
 
-        alpha = 1f + (progress * grade).let { -it * it }
+        alpha = (1f + (progress * grade).let { -it * it }).coerceIn(minimumAlpha, 1f)
     }
 }
 
@@ -100,10 +105,12 @@ fun cleanSlideAndFade(
     animationSpec: AnimationSpec<Float> = softSpring(),
     orientation: Orientation = Orientation.Horizontal,
     targetOffsetDp: Int = 64,
+    minimumAlpha: Float = 0.000001f,
     animateFadeUsingGestures: Boolean = false,
 ) = fade(
     clean = true,
     animateUsingGestures = animateFadeUsingGestures,
+    minimumAlpha = minimumAlpha,
     animationSpec = animationSpec
 ) + slide(
     orientation = orientation,

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/ContentAnimator.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/ContentAnimator.kt
@@ -16,7 +16,7 @@ value class ContentAnimations(val items: List<ContentAnimator<*>>)
 
 /**
  * Describes the animator and creates a scope. [key] is used to identify the scopes in
- * [StackAnimatorScope] and to minimize their creation, as scopes with the same animator type
+ * [StackAnimatorScope] and to minimize their creation, as scopes with the same animator animationType
  * and key will always have 1a single instance.
  */
 @Immutable

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
@@ -217,7 +217,7 @@ fun <C : Any, T : DecomposeChildInstance> StackAnimator(
 						}
 
 						if (animationStatus.animationType.passiveCancelling && indexFromTop == 0) {
-							seekableTransitionState.seekTo(-progress)
+							seekableTransitionState.seekTo(-progress.coerceIn(0f, 1f))
 						}
 					}
 

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
@@ -201,6 +201,12 @@ fun <C : Any, T : DecomposeChildInstance> StackAnimator(
 						if (indexFromTop == 0) seekableTransitionState.animateTo(instance)
 					}
 
+					LaunchedEffect(animationStatus.animating) {
+						if (indexFromTop == 0 && !animationStatus.animating) {
+							seekableTransitionState.snapTo(instance)
+						}
+					}
+
 					LaunchedEffect(progress) {
 						if (animationStatus.fromBackIntoTop) {
 							seekableTransitionState.seekTo(
@@ -217,7 +223,7 @@ fun <C : Any, T : DecomposeChildInstance> StackAnimator(
 						}
 
 						if (animationStatus.animationType.passiveCancelling && indexFromTop == 0) {
-							seekableTransitionState.seekTo(-progress.coerceIn(0f, 1f))
+							seekableTransitionState.seekTo((-progress).coerceIn(0f, 1f))
 						}
 					}
 

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
@@ -216,9 +216,6 @@ fun <C : Any, T : DecomposeChildInstance> StackAnimator(
 					LaunchedEffect(indexFromTop, index) {
 						animData.scopes.forEach { (_, scope) ->
 							launch {
-								// to remove
-								println("$child at indexFromTop: $indexFromTop, index: $index")
-
 								scope.update(
 									newIndex = index,
 									newIndexFromTop = indexFromTop,
@@ -251,7 +248,7 @@ fun <C : Any, T : DecomposeChildInstance> StackAnimator(
 									content(instance)
 									BasicText(
 										(firstAnimData.animationStatus as AnimationStatus).toTargetEnterExitState()
-											.toString() + "\n" + firstAnimData.animationStatus.toString() + "\n" + transitionState .toString(),
+											.toString() + "\n" + firstAnimData.animationStatus.toString() + "\n" + transitionState.toString(),
 										color = { Color.White },
 										modifier = Modifier.offset(y = 20.dp),
 										style = TextStyle(
@@ -287,7 +284,7 @@ private class AnimatedVisibilityScopeImpl(
 	override val transition: Transition<EnterExitState>
 ) : AnimatedVisibilityScope
 
-fun AnimationStatus.toCurrentEnterExitState() = when {
+private fun AnimationStatus.toCurrentEnterExitState() = when {
 	fromOutsideIntoTop -> EnterExitState.PreEnter
 	fromTopToOutside -> EnterExitState.Visible
 
@@ -303,7 +300,7 @@ fun AnimationStatus.toCurrentEnterExitState() = when {
 	else -> error("function toCurrentEnterExitState. $this")
 }
 
-fun AnimationStatus.toTargetEnterExitState() = when {
+private fun AnimationStatus.toTargetEnterExitState() = when {
 	fromOutsideIntoTop -> EnterExitState.Visible
 	fromTopToOutside -> EnterExitState.PostExit
 
@@ -319,23 +316,20 @@ fun AnimationStatus.toTargetEnterExitState() = when {
 	else -> error("function toTargetEnterExitState. $this")
 }
 
-// Function to calculate progress
-// animation progress:
-// 1f = in back stack = 0f reported progress
-// 0f = top of the stack/visible content = 1f reported progress
-// -1f = out of the stack/hidden content = 0f reported progress
-fun calculateTargetProgress(
+// Function to calculate target animation progress:
+// 1f = in back stack
+// 0f = top of the stack/visible content
+// -1f = out of the stack/hidden content
+private fun calculateTargetProgress(
 	targetState: EnterExitState,
 	animationProgress: Float,
 	animStatus: AnimationStatus
 ) = when (targetState) {
-	EnterExitState.PreEnter -> {
-		when {
-			animStatus.fromBackIntoTop -> 1f - animationProgress
-			!animStatus.animating && animStatus.location.top -> 1f
-			!animStatus.animating && animStatus.location.back || animStatus.fromBackToBack -> 0f
-			else -> error("function calculateTargetProgress. PreEnter. $animStatus")
-		}
+	EnterExitState.PreEnter -> when {
+		animStatus.fromBackIntoTop -> 1f - animationProgress
+		!animStatus.animating && animStatus.location.top -> 1f
+		!animStatus.animating && animStatus.location.back || animStatus.fromBackToBack -> 0f
+		else -> error("function calculateTargetProgress. PreEnter. $animStatus")
 	}
 
 	EnterExitState.Visible -> when {

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
@@ -292,7 +292,7 @@ private fun AnimationStatus.toCurrentEnterExitState() = when {
 	fromBackIntoTop -> EnterExitState.PreEnter
 
 	location.top && animationType.passiveCancelling -> EnterExitState.Visible
-	location.back && animationType.passiveCancelling -> EnterExitState.PostExit
+	location.back && animationType.passiveCancelling -> EnterExitState.PreEnter
 
 	location.top && !animating -> EnterExitState.Visible
 	(location.back && !animating) || fromBackToBack -> EnterExitState.PreEnter

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
@@ -1,9 +1,31 @@
 package com.nxoim.decomposite.core.common.navigation.animations
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.EnterExitState
+import androidx.compose.animation.core.SeekableTransitionState
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.rememberTransition
 import androidx.compose.foundation.layout.Box
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.zIndex
@@ -15,9 +37,13 @@ import com.arkivanov.decompose.router.stack.items
 import com.arkivanov.decompose.value.Value
 import com.nxoim.decomposite.core.common.navigation.DecomposeChildInstance
 import com.nxoim.decomposite.core.common.navigation.LocalNavigationRoot
+import com.nxoim.decomposite.core.common.navigation.animations.AnimationType.Companion.passiveCancelling
+import com.nxoim.decomposite.core.common.navigation.animations.ItemLocation.Companion.back
+import com.nxoim.decomposite.core.common.navigation.animations.ItemLocation.Companion.top
 import com.nxoim.decomposite.core.common.ultils.ImmutableThingHolder
 import com.nxoim.decomposite.core.common.ultils.OnDestinationDisposeEffect
 import com.nxoim.decomposite.core.common.ultils.ScreenInformation
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 /**
@@ -26,181 +52,291 @@ import kotlinx.coroutines.launch
 @OptIn(InternalDecomposeApi::class)
 @Composable
 fun <C : Any, T : DecomposeChildInstance> StackAnimator(
-    stackValue: ImmutableThingHolder<Value<ChildStack<C, T>>>,
-    stackAnimatorScope: StackAnimatorScope<C>,
-    modifier: Modifier = Modifier,
-    onBackstackChange: (stackEmpty: Boolean) -> Unit,
-    excludeStartingDestination: Boolean = false,
-    allowBatchRemoval: Boolean = true,
-    animations: DestinationAnimationsConfiguratorScope<C>.() -> ContentAnimations,
-    content: @Composable (child: Child.Created<C, T>) -> Unit,
+	stackValue: ImmutableThingHolder<Value<ChildStack<C, T>>>,
+	stackAnimatorScope: StackAnimatorScope<C>,
+	modifier: Modifier = Modifier,
+	onBackstackChange: (stackEmpty: Boolean) -> Unit,
+	excludeStartingDestination: Boolean = false,
+	allowBatchRemoval: Boolean = true,
+	animations: DestinationAnimationsConfiguratorScope<C>.() -> ContentAnimations,
+	content: @Composable AnimatedVisibilityScope.(child: Child.Created<C, T>) -> Unit,
 ) = with(stackAnimatorScope) {
-    key(stackAnimatorScope.key) {
-        val holder = rememberSaveableStateHolder()
-        var sourceStack by remember { mutableStateOf(stackValue.thing.value) }
-        val removingChildren = remember { mutableStateListOf<C>() }
-        val cachedChildrenInstances = remember {
-            mutableStateMapOf<C, Child.Created<C, T>>().apply {
-                putAll(
-                    stackValue.thing.items.subList(
-                        if (excludeStartingDestination) 1 else 0,
-                        stackValue.thing.items.size
-                    ).associateBy { it.configuration }
-                )
-            }
-        }
+	key(stackAnimatorScope.key) {
+		val holder = rememberSaveableStateHolder()
+		var sourceStack by remember { mutableStateOf(stackValue.thing.value) }
+		val removingChildren = remember { mutableStateListOf<C>() }
+		val cachedChildrenInstances = remember {
+			mutableStateMapOf<C, Child.Created<C, T>>().apply {
+				putAll(
+					stackValue.thing.items.subList(
+						if (excludeStartingDestination) 1 else 0,
+						stackValue.thing.items.size
+					).associateBy { it.configuration }
+				)
+			}
+		}
 
-        LaunchedEffect(Unit) {
-            // check on startup if there's animation data left for nonexistent children, which
-            // can happen during a configuration change
-            launch {
-                removeStaleAnimationDataCache(nonStale = sourceStack.items.fastMap { it.configuration } )
-            }
+		LaunchedEffect(Unit) {
+			// check on startup if there's animation data left for nonexistent children, which
+			// can happen during a configuration change
+			launch {
+				removeStaleAnimationDataCache(nonStale = sourceStack.items.fastMap { it.configuration })
+			}
 
-            stackValue.thing.subscribe { newStackRaw ->
-                onBackstackChange(newStackRaw.items.size <= 1)
-                val oldStack = sourceStack.items
-                val newStack = newStackRaw.items.subList(
-                    if (excludeStartingDestination) 1 else 0,
-                    stackValue.thing.items.size
-                )
+			stackValue.thing.subscribe { newStackRaw ->
+				onBackstackChange(newStackRaw.items.size <= 1)
+				val oldStack = sourceStack.items
+				val newStack = newStackRaw.items.subList(
+					if (excludeStartingDestination) 1 else 0,
+					stackValue.thing.items.size
+				)
 
-                val childrenToRemove = oldStack.filter { it !in newStack && it.configuration !in removingChildren }
-                val batchRemoval = childrenToRemove.size > 1 && allowBatchRemoval
+				val childrenToRemove =
+					oldStack.filter { it !in newStack && it.configuration !in removingChildren }
+				val batchRemoval = childrenToRemove.size > 1 && allowBatchRemoval
 
-                // cancel removal of items that appeared again in the stack
-                removingChildren.removeAll(newStackRaw.items.map { it.configuration })
+				// cancel removal of items that appeared again in the stack
+				removingChildren.removeAll(newStackRaw.items.map { it.configuration })
 
-                if (batchRemoval) {
-                    // remove from cache and everything all children, except the last one,
-                    // which will be animated
-                    val itemsToRemoveImmediately = childrenToRemove.subList(0, childrenToRemove.size - 1)
-                    itemsToRemoveImmediately.forEach { (configuration, _) ->
-                        cachedChildrenInstances.remove(configuration)
-                    }
-                    removingChildren.add(childrenToRemove.last().configuration)
-                } else {
-                    childrenToRemove.forEach {
-                        removingChildren.add(it.configuration)
-                    }
-                }
+				if (batchRemoval) {
+					// remove from cache and everything all children, except the last one,
+					// which will be animated
+					val itemsToRemoveImmediately =
+						childrenToRemove.subList(0, childrenToRemove.size - 1)
+					itemsToRemoveImmediately.forEach { (configuration, _) ->
+						cachedChildrenInstances.remove(configuration)
+					}
+					removingChildren.add(childrenToRemove.last().configuration)
+				} else {
+					childrenToRemove.forEach {
+						removingChildren.add(it.configuration)
+					}
+				}
 
-                sourceStack = newStackRaw
+				sourceStack = newStackRaw
 
-                cachedChildrenInstances.putAll(newStack.associateBy { it.configuration })
-            }
-        }
+				cachedChildrenInstances.putAll(newStack.associateBy { it.configuration })
+			}
+		}
 
-        Box(modifier) {
-            cachedChildrenInstances.forEach { (child, cachedInstance) ->
-                key(child) {
-                    val inStack = !removingChildren.contains(child)
-                    val instance by remember {
-                        derivedStateOf {
-                            sourceStack.items.find { it.configuration == child } ?: cachedInstance
-                        }
-                    }
+		Box(modifier) {
+			cachedChildrenInstances.forEach { (child, cachedInstance) ->
+				key(child) {
+					val inStack = !removingChildren.contains(child)
+					val instance by remember {
+						derivedStateOf {
+							sourceStack.items.find { it.configuration == child } ?: cachedInstance
+						}
+					}
 
-                    val index = if (inStack)
-                        sourceStack.items.indexOf(instance)
-                    else
-                        -(removingChildren.indexOf(child) + 1)
+					val index = if (inStack)
+						sourceStack.items.indexOf(instance)
+					else
+						-(removingChildren.indexOf(child) + 1)
 
-                    val indexFromTop = if (inStack)
-                        sourceStack.items.size - index - 1
-                    else
-                        -(removingChildren.indexOf(child) + 1)
+					val indexFromTop = if (inStack)
+						sourceStack.items.size - index - 1
+					else
+						-(removingChildren.indexOf(child) + 1)
 
-                    val allAnimations = animations(
-                        DestinationAnimationsConfiguratorScope(
-                            sourceStack.items.elementAt(index - 1).configuration,
-                            child,
-                            sourceStack.items.elementAt(index + 1).configuration,
-                            LocalNavigationRoot.current.screenInformation
-                        )
-                    )
+					val allAnimations = animations(
+						DestinationAnimationsConfiguratorScope(
+							sourceStack.items.elementAt(index - 1).configuration,
+							child,
+							sourceStack.items.elementAt(index + 1).configuration,
+							LocalNavigationRoot.current.screenInformation
+						)
+					)
 
-                    val animData = remember(allAnimations) {
-                        getOrCreateAnimationData(
-                            key = child,
-                            source = allAnimations,
-                            initialIndex = index,
-                            initialIndexFromTop = indexFromTop
-                        )
-                    }
+					val animData = remember(allAnimations) {
+						getOrCreateAnimationData(
+							key = child,
+							source = allAnimations,
+							initialIndex = index,
+							initialIndexFromTop = if (indexFromTop == 0 && index != 0)
+								-1
+							else
+								indexFromTop
+						)
+					}
 
-                    val allowingAnimation = indexFromTop <= (animData.renderUntils.min())
+					val allowingAnimation = indexFromTop <= (animData.renderUntils.min())
 
-                    val animating by remember {
-                        derivedStateOf {
-                            animData.scopes.any { it.value.animationStatus.animating }
-                        }
-                    }
+					val animating by remember {
+						derivedStateOf {
+							animData.scopes.any { it.value.animationStatus.animating }
+						}
+					}
 
-                    val displaying = remember(animating, allowingAnimation) {
-                        val requireVisibilityInBack = animData.requireVisibilityInBackstacks.fastAny { it }
-                        val renderingBack = allowingAnimation && animating
-                        val renderTopAndAnimatedBack = indexFromTop < 1 || renderingBack
-                        if (requireVisibilityInBack) allowingAnimation else renderTopAndAnimatedBack
-                    }
+					val displaying = remember(animating, allowingAnimation) {
+						val requireVisibilityInBack =
+							animData.requireVisibilityInBackstacks.fastAny { it }
+						val renderingBack = allowingAnimation && animating
+						val renderTopAndAnimatedBack = indexFromTop < 1 || renderingBack
+						if (requireVisibilityInBack) allowingAnimation else renderTopAndAnimatedBack
+					}
 
-                    LaunchedEffect(allowingAnimation, inStack) {
-                        stackAnimatorScope.updateChildAnimPrerequisites(
-                            child,
-                            allowingAnimation,
-                            inStack
-                        )
-                    }
+					val firstAnimData = animData.scopes.values.first()
 
-                    // launch animations if there's changes
-                    LaunchedEffect(indexFromTop, index) {
-                        animData.scopes.forEach { (_, scope) ->
-                            launch {
-                                scope.update(
-                                    index,
-                                    indexFromTop,
-                                    animate = scope.indexFromTop != indexFromTop || indexFromTop < 1
-                                )
+					// i have no idea how to use EnterExitState. i literally
+					// bruteforced this. it took me 2 days
+					val transitionState = remember {
+						SeekableTransitionState(EnterExitState.PostExit)
+					}
+					val transition = rememberTransition(transitionState)
+					val animatedVisibilityScope =
+						remember { AnimatedVisibilityScopeImpl(transition) }
 
-                                // after animating, if is not in stack
-                                if (!inStack) cachedChildrenInstances.remove(child)
-                            }
-                        }
-                    }
+					LaunchedEffect(firstAnimData.animationStatus) {
+						snapshotFlow { firstAnimData.animationProgressForScope.value }
+							.collectLatest() { animationProgress ->
+								val animStatus = firstAnimData.animationStatus as AnimationStatus
+								val targetState = animStatus.toEnterExitState()
 
-                    // will get triggered upon removal
-                    OnDestinationDisposeEffect(
-                        instance.configuration.hashString() + stackAnimatorScope.key + "OnDestinationDisposeEffect",
-                        waitForCompositionRemoval = true,
-                        componentContext = instance.instance.componentContext
-                    ) {
-                        removingChildren.remove(child)
-                        removeAnimationDataFromCache(child)
-                        holder.removeState(childHolderKey(child))
-                    }
+								val targetProgess = calculateTargetProgress(
+									targetState,
+									animationProgress,
+									animStatus
+								)
 
-                    if (displaying) holder.SaveableStateProvider(childHolderKey(child)) {
-                        Box(
-                            Modifier.zIndex((-indexFromTop).toFloat()).accumulate(animData.modifiers),
-                            content = { content(instance) }
-                        )
-                    }
-                }
-            }
-        }
-    }
+								transitionState.seekTo(targetProgess, targetState)
+							}
+					}
+
+					LaunchedEffect(allowingAnimation, inStack) {
+						stackAnimatorScope.updateChildAnimPrerequisites(
+							child,
+							allowingAnimation,
+							inStack
+						)
+					}
+
+					// launch animations if there's changes
+					LaunchedEffect(indexFromTop, index) {
+						animData.scopes.forEach { (_, scope) ->
+							launch {
+								// to remove
+								println("$child at indexFromTop: $indexFromTop, index: $index")
+
+								scope.update(
+									newIndex = index,
+									newIndexFromTop = indexFromTop,
+									animate = scope.indexFromTop != indexFromTop || indexFromTop < 1
+								)
+
+								// after animating, if is not in stack
+								if (!inStack) cachedChildrenInstances.remove(child)
+							}
+						}
+					}
+
+					// will get triggered upon removal
+					OnDestinationDisposeEffect(
+						instance.configuration.hashString() + stackAnimatorScope.key + "OnDestinationDisposeEffect",
+						waitForCompositionRemoval = true,
+						componentContext = instance.instance.componentContext
+					) {
+						removingChildren.remove(child)
+						removeAnimationDataFromCache(child)
+						holder.removeState(childHolderKey(child))
+					}
+
+					with(animatedVisibilityScope) {
+						if (displaying) holder.SaveableStateProvider(childHolderKey(child)) {
+							Box(
+								Modifier.zIndex((-indexFromTop).toFloat())
+									.accumulate(animData.modifiers),
+								content = {
+									content(instance)
+									BasicText(
+										(firstAnimData.animationStatus as AnimationStatus).toEnterExitState()
+											.toString() + "\n" + firstAnimData.animationStatus.toString(),
+										color = { Color.White },
+										modifier = Modifier.offset(y = 20.dp),
+										style = TextStyle(
+											textAlign = TextAlign.Center,
+											fontSize = 8.sp
+										)
+									)
+								}
+							)
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 @OptIn(InternalDecomposeApi::class)
 private fun <C : Any> childHolderKey(child: C) =
-    child.hashString() + " StackAnimator SaveableStateHolder"
+	child.hashString() + " StackAnimator SaveableStateHolder"
 
 /**
  * Provides data helpful for the configuration of animations.
  */
 data class DestinationAnimationsConfiguratorScope<C : Any>(
-    val previousChild: C?,
-    val currentChild: C,
-    val nextChild: C?,
-    val screenInformation: ScreenInformation
+	val previousChild: C?,
+	val currentChild: C,
+	val nextChild: C?,
+	val screenInformation: ScreenInformation
 )
+
+private class AnimatedVisibilityScopeImpl(
+	override val transition: Transition<EnterExitState>
+) : AnimatedVisibilityScope
+
+fun AnimationStatus.toEnterExitState() = when {
+	fromOutsideIntoTop -> EnterExitState.Visible
+	fromTopToOutside -> EnterExitState.PostExit
+
+	fromTopIntoBack -> EnterExitState.PostExit
+	fromBackIntoTop -> EnterExitState.Visible
+
+	location.top && animationType.passiveCancelling -> EnterExitState.PostExit
+	location.back && animationType.passiveCancelling -> EnterExitState.PostExit
+
+	location.top && !animating -> EnterExitState.Visible
+	(location.back && !animating) || fromBackToBack -> EnterExitState.PreEnter
+
+	else -> EnterExitState.PreEnter
+}
+
+// Function to calculate progress
+// animation progress:
+// 1f = in back stack = 0f reported progress
+// 0f = top of the stack/visible content = 1f reported progress
+// -1f = out of the stack/hidden content = 0f reported progress
+fun calculateTargetProgress(
+	targetState: EnterExitState,
+	animationProgress: Float,
+	animStatus: AnimationStatus
+) = when (targetState) {
+	EnterExitState.PreEnter -> {
+		when {
+			animStatus.animationType.passiveCancelling && animStatus.location.top -> 1f - animationProgress
+			else -> 1f
+		}
+//		error("this is unused. how did this happen")
+	}
+
+	EnterExitState.Visible -> when {
+		animStatus.fromOutsideIntoTop -> 1f + animationProgress
+		animStatus.fromBackIntoTop -> 1f - animationProgress
+		animStatus.animationType.passiveCancelling && animStatus.location.top -> 1f - animationProgress
+		animStatus.animationType.passiveCancelling && animStatus.location.back -> animationProgress
+		!animStatus.animating && animStatus.location.top -> 1f
+		!animStatus.animating && animStatus.location.back -> 0f
+		else -> error("huh EnterExitState.Visible , $animStatus")
+	}
+
+	EnterExitState.PostExit -> when {
+		animStatus.fromTopToOutside -> -animationProgress
+		animStatus.fromTopIntoBack -> animationProgress
+		animStatus.animationType.passiveCancelling && animStatus.location.top -> 1f + animationProgress
+		animStatus.animationType.passiveCancelling && animStatus.location.back -> animationProgress
+		!animStatus.animating || animStatus.fromBackToBack -> 0f
+		else -> error("djhdndbnf")
+	}
+}.coerceIn(0f, 1f)
+

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/StackAnimator.kt
@@ -12,8 +12,6 @@ import androidx.compose.animation.core.Transition
 import androidx.compose.animation.core.createChildTransition
 import androidx.compose.animation.core.rememberTransition
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -29,7 +27,6 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import androidx.compose.ui.layout.IntrinsicMeasureScope
 import androidx.compose.ui.layout.Layout
@@ -38,12 +35,8 @@ import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.layout
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastMap
@@ -280,22 +273,6 @@ fun <C : Any, T : DecomposeChildInstance> StackAnimator(
 						holder.SaveableStateProvider(childHolderKey(child)) {
 							content(instance)
 						}
-
-						val text = """
-							from ${this.transition.currentState} to ${this.transition.targetState}
-							
-							${this.transition}
-						""".trimIndent()
-
-						BasicText(
-							text,
-							color = { Color.White },
-							modifier = Modifier.offset(y = 60.dp),
-							style = TextStyle(
-								textAlign = TextAlign.Center,
-								fontSize = 8.sp
-							)
-						)
 					}
 				}
 			}
@@ -405,13 +382,13 @@ private class AnimatedEnterExitMeasurePolicy(
 /**
  * Observes lookahead size.
  */
-fun interface OnLookaheadMeasured {
+private fun interface OnLookaheadMeasured {
 	fun invoke(size: IntSize)
 }
 
 @OptIn(InternalAnimationApi::class, ExperimentalTransitionApi::class)
 @Composable
-internal fun <T> AnimatedVisibilityScopeProvider(
+private fun <T> AnimatedVisibilityScopeProvider(
 	transition: Transition<T>,
 	visible: (T) -> Boolean,
 	modifier: Modifier,

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/ContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/ContentAnimatorScope.kt
@@ -10,9 +10,18 @@ import com.nxoim.decomposite.core.common.ultils.BackGestureEvent
  * Base for the content animator scope implementations. Describes the bare minimum
  * needed. When implementing - keep in mind:
  * - elements, appearing and disappearing from the stack, update the state and trigger animations
+ *
  * - [onBackGesture] represents the user's actions and should not be used to manipulate the stack
+ *
  * - in [update], when animating exit - let the animation code (be it animateTo or animate) block
  * the thread so the content removal happens only after the animation has ended.
+ *
+ * - [indexFromTop] represents the index of the item from the top of the stack, with
+ * 0 being the top. Negative numbers represent an item not existing in the stack while being
+ * animated. If several items are being removed and all are animated at the same time - 
+ * [indexFromTop] will be represent the order of the items being removed, -1 being
+ * the latest item that has been removed. Yes, the number can be less than -1.
+ *
  *
  * [animationProgressForScope] describes the current progress of an animation
  * and is used for providing the [AnimatedVisibilityScope] to the content, for

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/ContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/ContentAnimatorScope.kt
@@ -1,5 +1,8 @@
 package com.nxoim.decomposite.core.common.navigation.animations.scopes
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.State
 import com.nxoim.decomposite.core.common.navigation.animations.AnimationStatus
 import com.nxoim.decomposite.core.common.ultils.BackGestureEvent
 
@@ -9,14 +12,23 @@ import com.nxoim.decomposite.core.common.ultils.BackGestureEvent
  * - elements, appearing and disappearing from the stack, update the state and trigger animations
  * - [onBackGesture] represents the user's actions and should not be used to manipulate the stack
  * - in [update], when animating exit - let the animation code (be it animateTo or animate) block
- * the thread so the content removal happens only after the animation has ended
+ * the thread so the content removal happens only after the animation has ended.
+ *
+ * [animationProgressForScope] describes the current progress of an animation
+ * and is used for providing the [AnimatedVisibilityScope] to the content, for
+ * things like modifiers that depend on [SharedTransitionScope].
+ * It must mirror [indexFromTop], meaning it must be -1 when the item is outside the stack,
+ * 0 when at the top of the stack, and 1 when at the back of the stack.
+ *
+ * Note: when several animations with different specs are used for a single item -
+ * the first scope is used to provide [animationProgressForScope].
  */
 interface ContentAnimatorScope {
     val indexFromTop: Int
     val index: Int
     val animationStatus: AnimationStatus
+    val animationProgressForScope: State<Float>
 
     suspend fun onBackGesture(backGesture: BackGestureEvent): Any
     suspend fun update(newIndex: Int, newIndexFromTop: Int, animate: Boolean = true)
 }
-

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
@@ -122,7 +122,7 @@ class DefaultContentAnimatorScope(
 	)
 
 	override suspend fun onBackGesture(backGesture: BackGestureEvent) = coroutineScope {
-		when (backGesture) {
+		if (indexFromTop >= 0) when (backGesture) {
 			is BackGestureEvent.OnBackStarted -> {
 				// stop all animations
 				animationProgressAnimatable.stop()
@@ -134,7 +134,7 @@ class DefaultContentAnimatorScope(
 
 				direction = Direction.Outwards
 				animationType = AnimationType.Gestures
-				updateAnimationStatusAfterAllChanges()
+				updateAnimationStatusAfterAllChanges("onBackStarted")
 			}
 
 			is BackGestureEvent.OnBackProgressed -> {
@@ -145,7 +145,7 @@ class DefaultContentAnimatorScope(
 				// while a gesture is in progress. this makes sure that doesn't happen
 				direction = Direction.Outwards
 				animationType = AnimationType.Gestures
-				updateAnimationStatusAfterAllChanges()
+				updateAnimationStatusAfterAllChanges("onBackProgressed")
 
 				gestureAnimationProgressAnimatable
 					.snapTo(animationProgress - backGesture.event.progress)
@@ -164,7 +164,6 @@ class DefaultContentAnimatorScope(
 			BackGestureEvent.OnBackCancelled -> {
 				direction = Direction.Inwards
 				animationType = AnimationType.PassiveCancelling
-//				updateAnimationStatusAfterAllChanges()
 				animateToTarget()
 			}
 
@@ -204,7 +203,7 @@ class DefaultContentAnimatorScope(
 
 	private suspend fun animateToTarget() = coroutineScope {
 		val velocity = velocityTracker.calculateVelocity().x
-		updateAnimationStatusAfterAllChanges()
+		updateAnimationStatusAfterAllChanges("animateToTarget beginning")
 
 		launch {
 			gestureAnimationProgressAnimatable.animateTo(
@@ -234,19 +233,23 @@ class DefaultContentAnimatorScope(
 
 			direction = Direction.None
 			animationType = AnimationType.None
-			updateAnimationStatusAfterAllChanges()
+			updateAnimationStatusAfterAllChanges("animateToTarget launch block")
 
 			backEvent = BackEvent()
 		}
 	}
 
-	private fun updateAnimationStatusAfterAllChanges() {
+	private fun updateAnimationStatusAfterAllChanges(updateFrom: String) {
+		println("current: $animationStatus. updateFrom: $updateFrom")
+
 		val newStatus = AnimationStatus(
 			previousLocation = previousIndexFromTop?.let { toItemLocation(it) },
 			location = toItemLocation(indexFromTop),
 			direction = direction,
 			animationType = animationType
 		)
+
+		println("newStatus: $newStatus. updateFrom: $updateFrom")
 
 		animationStatus = newStatus
 	}

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
@@ -122,7 +122,7 @@ class DefaultContentAnimatorScope(
 	)
 
 	override suspend fun onBackGesture(backGesture: BackGestureEvent) = coroutineScope {
-		if (indexFromTop >= 0) when (backGesture) {
+		when (backGesture) {
 			is BackGestureEvent.OnBackStarted -> {
 				// stop all animations
 				animationProgressAnimatable.stop()
@@ -170,6 +170,8 @@ class DefaultContentAnimatorScope(
 			BackGestureEvent.OnBack -> {
 				direction = Direction.Outwards
 				animationType = AnimationType.Passive
+				// on BackGestureEvent.OnBack an item is removed, and that will
+				// trigger [update] function, updating the state and triggering an animation
 			}
 		}
 	}
@@ -185,9 +187,6 @@ class DefaultContentAnimatorScope(
 			else -> Direction.None
 		}
 
-		// to remove
-		println("$newIndexFromTop, $indexFromTop, newDirection: $newDirection")
-
 		previousIndexFromTop = indexFromTop
 
 		index = newIndex
@@ -195,8 +194,6 @@ class DefaultContentAnimatorScope(
 
 		direction = newDirection
 		animationType = if (newDirection.none) AnimationType.None else AnimationType.Passive
-//
-//		updateAnimationStatusAfterAllChanges()
 
 		if (animate) animateToTarget()
 	}
@@ -228,9 +225,6 @@ class DefaultContentAnimatorScope(
 				withFrameMillis {  } // wait for both to finish
 			}
 
-			// to remove
-			println("animationEnd")
-
 			direction = Direction.None
 			animationType = AnimationType.None
 			updateAnimationStatusAfterAllChanges()
@@ -240,14 +234,12 @@ class DefaultContentAnimatorScope(
 	}
 
 	private fun updateAnimationStatusAfterAllChanges() {
-		val newStatus = AnimationStatus(
+		animationStatus = AnimationStatus(
 			previousLocation = previousIndexFromTop?.let { toItemLocation(it) },
 			location = toItemLocation(indexFromTop),
 			direction = direction,
 			animationType = animationType
 		)
-
-		animationStatus = newStatus
 	}
 }
 

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
@@ -134,7 +134,7 @@ class DefaultContentAnimatorScope(
 
 				direction = Direction.Outwards
 				animationType = AnimationType.Gestures
-				updateAnimationStatusAfterAllChanges("onBackStarted")
+				updateAnimationStatusAfterAllChanges()
 			}
 
 			is BackGestureEvent.OnBackProgressed -> {
@@ -145,7 +145,7 @@ class DefaultContentAnimatorScope(
 				// while a gesture is in progress. this makes sure that doesn't happen
 				direction = Direction.Outwards
 				animationType = AnimationType.Gestures
-				updateAnimationStatusAfterAllChanges("onBackProgressed")
+				updateAnimationStatusAfterAllChanges()
 
 				gestureAnimationProgressAnimatable
 					.snapTo(animationProgress - backGesture.event.progress)
@@ -180,8 +180,8 @@ class DefaultContentAnimatorScope(
 		animate: Boolean
 	) {
 		val newDirection = when {
+			newIndexFromTop <= -1 || newIndexFromTop < indexFromTop -> Direction.Outwards
 			newIndexFromTop > indexFromTop -> Direction.Inwards
-			newIndexFromTop < indexFromTop -> Direction.Outwards
 			else -> Direction.None
 		}
 
@@ -203,7 +203,7 @@ class DefaultContentAnimatorScope(
 
 	private suspend fun animateToTarget() = coroutineScope {
 		val velocity = velocityTracker.calculateVelocity().x
-		updateAnimationStatusAfterAllChanges("animateToTarget beginning")
+		updateAnimationStatusAfterAllChanges()
 
 		launch {
 			gestureAnimationProgressAnimatable.animateTo(
@@ -233,23 +233,19 @@ class DefaultContentAnimatorScope(
 
 			direction = Direction.None
 			animationType = AnimationType.None
-			updateAnimationStatusAfterAllChanges("animateToTarget launch block")
+			updateAnimationStatusAfterAllChanges()
 
 			backEvent = BackEvent()
 		}
 	}
 
-	private fun updateAnimationStatusAfterAllChanges(updateFrom: String) {
-		println("current: $animationStatus. updateFrom: $updateFrom")
-
+	private fun updateAnimationStatusAfterAllChanges() {
 		val newStatus = AnimationStatus(
 			previousLocation = previousIndexFromTop?.let { toItemLocation(it) },
 			location = toItemLocation(indexFromTop),
 			direction = direction,
 			animationType = animationType
 		)
-
-		println("newStatus: $newStatus. updateFrom: $updateFrom")
 
 		animationStatus = newStatus
 	}

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
@@ -245,7 +245,7 @@ class DefaultContentAnimatorScope(
 }
 
 private fun toItemLocation(indexFromTop: Int): ItemLocation = when {
-	indexFromTop < 0 -> ItemLocation.Outside
+	indexFromTop < 0 -> ItemLocation.Outside(indexFromTop)
 	indexFromTop == 0 -> ItemLocation.Top
 	indexFromTop > 0 -> ItemLocation.Back(indexFromTop)
 	else -> error("Unexpected indexFromTop value: $indexFromTop")

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/DefaultContentAnimatorScope.kt
@@ -2,19 +2,30 @@ package com.nxoim.decomposite.core.common.navigation.animations.scopes
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationSpec
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import com.arkivanov.decompose.InternalDecomposeApi
 import com.arkivanov.decompose.hashString
 import com.arkivanov.essenty.backhandler.BackEvent
-import com.nxoim.decomposite.core.common.navigation.animations.*
+import com.nxoim.decomposite.core.common.navigation.animations.AnimationStatus
+import com.nxoim.decomposite.core.common.navigation.animations.AnimationType
+import com.nxoim.decomposite.core.common.navigation.animations.ContentAnimations
+import com.nxoim.decomposite.core.common.navigation.animations.ContentAnimator
+import com.nxoim.decomposite.core.common.navigation.animations.Direction
+import com.nxoim.decomposite.core.common.navigation.animations.Direction.Companion.none
+import com.nxoim.decomposite.core.common.navigation.animations.ItemLocation
+import com.nxoim.decomposite.core.common.navigation.animations.softSpring
 import com.nxoim.decomposite.core.common.ultils.BackGestureEvent
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 /**
  * Creates an animation scope.
@@ -32,217 +43,218 @@ import kotlinx.coroutines.sync.withLock
  */
 @OptIn(InternalDecomposeApi::class)
 fun contentAnimator(
-    animationSpec: AnimationSpec<Float> = softSpring(),
-    renderUntil: Int = 1,
-    requireVisibilityInBackstack: Boolean = false,
-    block: DefaultContentAnimatorScope.() -> Modifier
+	animationSpec: AnimationSpec<Float> = softSpring(),
+	renderUntil: Int = 1,
+	requireVisibilityInBackstack: Boolean = false,
+	block: DefaultContentAnimatorScope.() -> Modifier
 ) = ContentAnimations(
-    listOf(
-        ContentAnimator(
-            key = animationSpec.hashString() + "DefaultContentAnimator", // 1 instance per animation spec
-            renderUntil = renderUntil,
-            requireVisibilityInBackstack = requireVisibilityInBackstack,
-            animatorScopeFactory = { initialIndex, initialIndexFromTop ->
-                DefaultContentAnimatorScope(initialIndex, initialIndexFromTop, animationSpec)
-            },
-            animationModifier = block
-        )
-    )
+	listOf(
+		ContentAnimator(
+			key = animationSpec.hashString() + "DefaultContentAnimator", // 1 instance per animation spec
+			renderUntil = renderUntil,
+			requireVisibilityInBackstack = requireVisibilityInBackstack,
+			animatorScopeFactory = { initialIndex, initialIndexFromTop ->
+				DefaultContentAnimatorScope(initialIndex, initialIndexFromTop, animationSpec)
+			},
+			animationModifier = block
+		)
+	)
 )
 
 @Immutable
 class DefaultContentAnimatorScope(
-    initialIndex: Int,
-    initialIndexFromTop: Int,
-    private val animationSpec: AnimationSpec<Float>
+	private val initialIndex: Int,
+	private val initialIndexFromTop: Int,
+	private val animationSpec: AnimationSpec<Float>
 ) : ContentAnimatorScope {
-    private val mutex = Mutex()
-    private var _indexFromTop by mutableIntStateOf(initialIndexFromTop)
-    override val indexFromTop get() = _indexFromTop
-    private var _index by mutableIntStateOf(initialIndex)
-    override val index get() = _index
-    private val initial get() = _index == 0
-    private val velocityTracker = VelocityTracker()
+	override var indexFromTop by mutableIntStateOf(initialIndexFromTop)
+		private set
 
-    private val location
-        get() = when {
-            _indexFromTop <= -1 -> ItemLocation.Outside
-            _indexFromTop == 0 -> ItemLocation.Top
-            _indexFromTop >= 1 -> ItemLocation.Back
-            else -> error("how")
-        }
+	override var index by mutableIntStateOf(initialIndex)
+		private set
+	private val initial get() = index == 0
 
-    // standard progress
-    private val animationProgressAnimatable = Animatable(if (initial) 0f else -1f)
+	private var previousIndexFromTop by mutableStateOf(
+		when {
+			initial -> 0
+			initialIndexFromTop == 0 -> -1
+			else -> null
+		}
+	)
 
-    // progress - gesture progress
-    private val gestureAnimationProgressAnimatable = Animatable(animationProgressAnimatable.value)
+	private val velocityTracker = VelocityTracker()
 
-    private var _backEvent by mutableStateOf(BackEvent())
-    val backEvent get() = _backEvent
-    private var initialSwipeOffset by mutableStateOf(Offset.Zero)
+	// standard progress
+	private val animationProgressAnimatable = Animatable(if (initial) 0f else -1f)
 
-    val animationProgress by animationProgressAnimatable.asState()
-    val gestureAnimationProgress by gestureAnimationProgressAnimatable.asState()
+	// progress minus gesture progress
+	private val gestureAnimationProgressAnimatable = Animatable(animationProgressAnimatable.value)
 
-    val swipeOffset get() = Offset(
-        initialSwipeOffset.x - _backEvent.touchX,
-        initialSwipeOffset.y - _backEvent.touchY
-    )
+	var backEvent by mutableStateOf(BackEvent())
+		private set
 
-    private var _animationStatus by mutableStateOf(
-        DefaultAnimationStatus(
-            previousLocation = if (initial) ItemLocation.Top else ItemLocation.Outside,
-            location = ItemLocation.Top,
-            direction = if (initial) Direction.None else Direction.Inward,
-            type = if (initial) AnimationType.None else AnimationType.Passive
-        )
-    )
+	private var initialSwipeOffset by mutableStateOf(Offset.Zero)
 
-    override val animationStatus get() = _animationStatus
+	val animationProgress by animationProgressAnimatable.asState()
+	val gestureAnimationProgress by gestureAnimationProgressAnimatable.asState()
+	override val animationProgressForScope = gestureAnimationProgressAnimatable.asState()
 
-    override suspend fun onBackGesture(backGesture: BackGestureEvent) = coroutineScope {
-        when (backGesture) {
-            is BackGestureEvent.OnBackStarted -> {
-                // stop all animations
-                animationProgressAnimatable.stop()
-                gestureAnimationProgressAnimatable.stop()
+	val swipeOffset
+		get() = Offset(
+			initialSwipeOffset.x - backEvent.touchX,
+			initialSwipeOffset.y - backEvent.touchY
+		)
 
-                initialSwipeOffset = Offset(backGesture.event.touchX, backGesture.event.touchY)
-                _backEvent = backGesture.event
-                velocityTracker.resetTracking()
+	private var direction by mutableStateOf(
+		if (initial) Direction.None else Direction.Inwards
+	)
+	private var animationType by mutableStateOf(
+		if (direction.none) AnimationType.None else AnimationType.Passive
+	)
 
-                updateStatus(
-                    _animationStatus.location,
-                    location,
-                    Direction.Outward,
-                    AnimationType.Gestures,
-                )
-            }
+	override var animationStatus by mutableStateOf(
+		AnimationStatus(
+			previousLocation = previousIndexFromTop?.let { toItemLocation(it) },
+			location = toItemLocation(initialIndexFromTop.coerceAtLeast(0)),
+			direction = direction,
+			animationType = animationType
+		)
+	)
 
-            is BackGestureEvent.OnBackProgressed -> {
-                _backEvent = backGesture.event
+	override suspend fun onBackGesture(backGesture: BackGestureEvent) = coroutineScope {
+		when (backGesture) {
+			is BackGestureEvent.OnBackStarted -> {
+				// stop all animations
+				animationProgressAnimatable.stop()
+				gestureAnimationProgressAnimatable.stop()
 
-                gestureAnimationProgressAnimatable.snapTo(animationProgress - backGesture.event.progress)
-                updateStatus(
-                    _animationStatus.location,
-                    location,
-                    Direction.Outward,
-                    AnimationType.Gestures,
-                )
+				initialSwipeOffset = Offset(backGesture.event.touchX, backGesture.event.touchY)
+				backEvent = backGesture.event
+				velocityTracker.resetTracking()
 
-                launch {
-                    withFrameMillis { frameTimeMillis ->
-                        velocityTracker.addPosition(
-                            timeMillis = frameTimeMillis,
-                            position = Offset(gestureAnimationProgress, 0f)
-                        )
-                    }
-                }
-            }
+				direction = Direction.Outwards
+				animationType = AnimationType.Gestures
+				updateAnimationStatusAfterAllChanges()
+			}
 
-            BackGestureEvent.None,
-            BackGestureEvent.OnBackCancelled -> {
-                updateStatus(
-                    _animationStatus.location,
-                    location,
-                    Direction.Inward,
-                    AnimationType.Passive,
-                )
-                animateToTarget()
-            }
+			is BackGestureEvent.OnBackProgressed -> {
+				backEvent = backGesture.event
 
-            BackGestureEvent.OnBack -> {
-                updateStatus(
-                    _animationStatus.location,
-                    location,
-                    Direction.Outward,
-                    AnimationType.Passive
-                )
-            }
-        }
-    }
+				// an animation can be kinda cancelled (see AnimationType.PassiveCancelling)
+				// meaning the direction and type might be updated to none
+				// while a gesture is in progress. this makes sure that doesn't happen
+				direction = Direction.Outwards
+				animationType = AnimationType.Gestures
+				updateAnimationStatusAfterAllChanges()
 
-    override suspend fun update(
-        newIndex: Int,
-        newIndexFromTop: Int,
-        animate: Boolean
-    ) {
-        val newDirection = when {
-            newIndexFromTop > _indexFromTop -> Direction.Inward
-            newIndexFromTop < _indexFromTop -> Direction.Outward
-            else -> _animationStatus.direction
-        }
+				gestureAnimationProgressAnimatable
+					.snapTo(animationProgress - backGesture.event.progress)
 
-        val newLocation = when {
-            newIndexFromTop <= -1 -> ItemLocation.Outside
-            newIndexFromTop == 0 -> ItemLocation.Top
-            newIndexFromTop >= 1 -> ItemLocation.Back
-            else -> error("how")
-        }
+				launch {
+					withFrameMillis { frameTimeMillis ->
+						velocityTracker.addPosition(
+							timeMillis = frameTimeMillis,
+							position = Offset(gestureAnimationProgress, 0f)
+						)
+					}
+				}
+			}
 
-        val previousLocation = if (newIndexFromTop == 0 && newDirection == Direction.Inward) {
-            ItemLocation.Outside
-        } else {
-            location
-        }
+			BackGestureEvent.None,
+			BackGestureEvent.OnBackCancelled -> {
+				direction = Direction.Inwards
+				animationType = AnimationType.PassiveCancelling
+//				updateAnimationStatusAfterAllChanges()
+				animateToTarget()
+			}
 
-        _index = newIndex
-        _indexFromTop = newIndexFromTop
+			BackGestureEvent.OnBack -> {
+				direction = Direction.Outwards
+				animationType = AnimationType.Passive
+			}
+		}
+	}
 
-        if (animate) {
-            updateStatus(previousLocation, newLocation, newDirection, AnimationType.Passive)
-            animateToTarget()
-        } else {
-            updateStatus(previousLocation, newLocation, Direction.None, AnimationType.None)
-        }
-    }
+	override suspend fun update(
+		newIndex: Int,
+		newIndexFromTop: Int,
+		animate: Boolean
+	) {
+		val newDirection = when {
+			newIndexFromTop > indexFromTop -> Direction.Inwards
+			newIndexFromTop < indexFromTop -> Direction.Outwards
+			else -> Direction.None
+		}
 
-    private suspend fun animateToTarget() = coroutineScope {
-        val velocity = velocityTracker.calculateVelocity().x
+		// to remove
+		println("$newIndexFromTop, $indexFromTop, newDirection: $newDirection")
 
-        launch {
-            gestureAnimationProgressAnimatable.animateTo(
-                targetValue = (_indexFromTop.coerceAtLeast(-1)).toFloat(),
-                animationSpec = animationSpec,
-                initialVelocity = velocity
-            )
-        }
+		previousIndexFromTop = indexFromTop
 
-        animationProgressAnimatable.animateTo(
-            targetValue = (_indexFromTop.coerceAtLeast(-1)).toFloat(),
-            animationSpec = animationSpec,
-            initialVelocity = velocity
-        )
+		index = newIndex
+		indexFromTop = newIndexFromTop
 
-        launch {
-            // for a moment this block will be called upon OnBack because that's animateTo's
-            // intended behavior, meaning these will be called unintentionally, unintentionally
-            // updating animation status. adding a delay compensates for this
-            withFrameNanos {  }
-            updateStatus(
-                _animationStatus.location,
-                location,
-                Direction.None,
-                AnimationType.None
-            )
-            _backEvent = BackEvent()
-        }
-    }
+		direction = newDirection
+		animationType = if (newDirection.none) AnimationType.None else AnimationType.Passive
+//
+//		updateAnimationStatusAfterAllChanges()
 
-    private suspend fun updateStatus(
-        previousLocation: ItemLocation,
-        newItemLocation: ItemLocation,
-        newDirection: Direction,
-        newType: AnimationType
-    ) {
-        mutex.withLock {
-            _animationStatus = DefaultAnimationStatus(
-                previousLocation = previousLocation,
-                location = newItemLocation,
-                direction = newDirection,
-                type = newType
-            )
-        }
-    }
+		if (animate) animateToTarget()
+	}
+
+	private suspend fun animateToTarget() = coroutineScope {
+		val velocity = velocityTracker.calculateVelocity().x
+		updateAnimationStatusAfterAllChanges()
+
+		launch {
+			gestureAnimationProgressAnimatable.animateTo(
+				targetValue = (indexFromTop.coerceAtLeast(-1)).toFloat(),
+				animationSpec = animationSpec,
+				initialVelocity = velocity
+			)
+		}
+
+		animationProgressAnimatable.animateTo(
+			targetValue = (indexFromTop.coerceAtLeast(-1)).toFloat(),
+			animationSpec = animationSpec,
+			initialVelocity = velocity
+		)
+
+		launch {
+			// for a moment this block will be called upon OnBack because that's animateTo's
+			// intended behavior, meaning these will be called unintentionally, unintentionally
+			// updating animation status. adding a delay compensates for this
+			withFrameNanos { }
+			while (gestureAnimationProgressAnimatable.isRunning) {
+				withFrameMillis {  } // wait for both to finish
+			}
+
+			// to remove
+			println("animationEnd")
+
+			direction = Direction.None
+			animationType = AnimationType.None
+			updateAnimationStatusAfterAllChanges()
+
+			backEvent = BackEvent()
+		}
+	}
+
+	private fun updateAnimationStatusAfterAllChanges() {
+		val newStatus = AnimationStatus(
+			previousLocation = previousIndexFromTop?.let { toItemLocation(it) },
+			location = toItemLocation(indexFromTop),
+			direction = direction,
+			animationType = animationType
+		)
+
+		animationStatus = newStatus
+	}
+}
+
+private fun toItemLocation(indexFromTop: Int): ItemLocation = when {
+	indexFromTop < 0 -> ItemLocation.Outside
+	indexFromTop == 0 -> ItemLocation.Top
+	indexFromTop > 0 -> ItemLocation.Back(indexFromTop)
+	else -> error("Unexpected indexFromTop value: $indexFromTop")
 }

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/MaterialContainerMorphContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/MaterialContainerMorphContentAnimatorScope.kt
@@ -158,15 +158,14 @@ internal class MaterialContainerMorphContentAnimatorScope(
                 direction = Direction.Inwards
                 animationType = AnimationType.PassiveCancelling
 
-                updateAnimationStatusAfterAllChanges()
                 animateToTarget()
             }
 
             BackGestureEvent.OnBack -> {
                 direction = Direction.Outwards
                 animationType = AnimationType.Passive
-
-                updateAnimationStatusAfterAllChanges()
+                // on BackGestureEvent.OnBack an item is removed, and that will
+                // trigger [update] function, updating the state and triggering an animation
             }
         }
     }
@@ -177,13 +176,10 @@ internal class MaterialContainerMorphContentAnimatorScope(
         animate: Boolean
     ) {
         val newDirection = when {
+            newIndexFromTop <= -1 || newIndexFromTop < indexFromTop -> Direction.Outwards
             newIndexFromTop > indexFromTop -> Direction.Inwards
-            newIndexFromTop < indexFromTop -> Direction.Outwards
             else -> Direction.None
         }
-
-        // to remove
-        println("$newIndexFromTop, $indexFromTop, newDirection: $newDirection")
 
         previousIndexFromTop = indexFromTop
 
@@ -193,12 +189,11 @@ internal class MaterialContainerMorphContentAnimatorScope(
         direction = newDirection
         animationType = if (newDirection.none) AnimationType.None else AnimationType.Passive
 
-        updateAnimationStatusAfterAllChanges()
-
         if (animate) animateToTarget()
     }
 
     private suspend fun animateToTarget() = coroutineScope {
+        updateAnimationStatusAfterAllChanges()
         // if the location is outside - report that a removal from the screen is needed by
         // not animating the progress, as animateTo delays that action
 

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/MaterialContainerMorphContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/MaterialContainerMorphContentAnimatorScope.kt
@@ -257,7 +257,7 @@ internal class MaterialContainerMorphContentAnimatorScope(
 }
 
 private fun toItemLocation(indexFromTop: Int): ItemLocation = when {
-    indexFromTop < 0 -> ItemLocation.Outside
+    indexFromTop < 0 -> ItemLocation.Outside(indexFromTop)
     indexFromTop == 0 -> ItemLocation.Top
     indexFromTop > 0 -> ItemLocation.Back(indexFromTop)
     else -> error("Unexpected indexFromTop value: $indexFromTop")

--- a/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/MaterialContainerMorphContentAnimatorScope.kt
+++ b/core/src/commonMain/kotlin/com/nxoim/decomposite/core/common/navigation/animations/scopes/MaterialContainerMorphContentAnimatorScope.kt
@@ -136,15 +136,16 @@ internal class MaterialContainerMorphContentAnimatorScope(
             }
 
             is BackGestureEvent.OnBackProgressed -> {
+                // an animation can be kinda cancelled (see AnimationType.PassiveCancelling)
+                // meaning the direction and type might be updated to none
+                // while a gesture is in progress. this makes sure that doesn't happen
+                direction = Direction.Outwards
+                animationType = AnimationType.Gestures
+                updateAnimationStatusAfterAllChanges()
+
+
                 if (location.top) {
                     gestureAnimationProgressAnimatable.snapTo(animationProgress - backGesture.event.progress)
-
-                    // an animation can be kinda cancelled (see AnimationType.PassiveCancelling)
-                    // meaning the direction and type might be updated to none
-                    // while a gesture is in progress. this makes sure that doesn't happen
-                    direction = Direction.Outwards
-                    animationType = AnimationType.Gestures
-                    updateAnimationStatusAfterAllChanges()
 
                     swipeOffsetAnimatable.snapTo(
                         IntOffset(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.9.22"
 agp = "8.2.2"
-compose = "1.6.1"
+compose = "1.7.0-alpha01"
 androidx-appcompat = "1.6.1"
 androidx-activityCompose = "1.8.2"
 compose-uitooling = "1.6.3"


### PR DESCRIPTION
StackAnimator (affects NavHost): extended the content lambda with AnimatedVisibilityScope

AnimationStatus(affects ContentAnimatorScope, DefaultContentAnimator, MaterialContainerMorphContentAnimator): 
- revert back to requiring the usage of decomposite's default animation status data class. StackAnimator requires it to report the correct animation state in AnimatedVisibilityScope
- added extensions
- changed ItemLocation so that the item's index in the stack could be passed into it
- added documentation
- moved some things around

DefaultContentAnimator & MaterialContainerMorphContentAnimator: refactored the logic a bit

ContentAnimatorScope:
- updated documentation
- added animationProgressForScope as a way to report the animation progress via the StackAnimator